### PR TITLE
Bump upstream littlefs to v2.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "littlefs2-sys"
 description = "Low-level bindings to littlefs"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Low-level bindings to the [littlefs][littlefs] microcontroller filesystem.
 
 You probably want the high-level, idiomatic Rust bindings: [littlefs2][littlefs2]
 
-Upstream release: [v2.2.1][upstream-release]
+Upstream release: [v2.3.0][upstream-release]
 
 [littlefs]: https://github.com/ARMmbed/littlefs
 [littlefs2]: https://github.com/nickray/littlefs2
-[upstream-release]: https://github.com/ARMmbed/littlefs/releases/tag/v2.2.1
+[upstream-release]: https://github.com/ARMmbed/littlefs/releases/tag/v2.3.0
 
 #### License
 


### PR DESCRIPTION
There are some new warnings, if anyone needs this, please test and report.