### PR TITLE
Add runtime feature to bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/nickray/littlefs2-sys"
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = { version = "0.56.0", default-features = false }
+bindgen = { version = "0.56.0", default-features = false , features = ["runtime"] }
 cc = "1"
 
 [features]


### PR DESCRIPTION
This is due to https://github.com/rust-lang/rust-bindgen/issues/2030#issuecomment-1203037292

We're not sure it's the recommended solution but it solves our conflict with `nettle-sys`. Ideally bindgen will either provide a fix or a recommended solution.