### PR TITLE
Release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.7] - 2022-01-26
+
+### Fixed
+
+- Fixed compilation issue caused by other crates also using `bindgen` by selecting the `runtime` feature ([#5])
+
+[#5]: https://github.com/trussed-dev/littlefs2-sys/pull/5
+
+[Unreleased]: https://github.com/trussed-dev/littlefs2-sys/compare/0.1.7...HEAD
+[0.1.7]: https://github.com/trussed-dev/littlefs2-sys/compare/0.1.6...0.1.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "littlefs2-sys"
 description = "Low-level bindings to littlefs"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
### Fixed

- Fixed compilation issue caused by other crates also using `bindgen` by selecting the `runtime` feature ([#5])

[#5]: https://github.com/trussed-dev/littlefs2-sys/pull/5

----

@nickray Can you also add the a tag for the v0.1.6 release so that it’s easier to compare the changes?