### PR TITLE
Bump littlefs version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "littlefs2-sys"
 description = "Low-level bindings to littlefs"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Nicolas Stalder <n@stalder.io>"]
-edition = "2018"
+edition = "2021"
 license = "BSD-3-Clause"
 readme = "README.md"
 categories = ["embedded", "filesystem", "no-std"]
 repository = "https://github.com/nickray/littlefs2-sys"
 
 [dependencies]
-cty = "0.2.1"
+cty = "0.2.2"
 
 [build-dependencies]
-bindgen = { version = "0.56.0", default-features = false , features = ["runtime"] }
+bindgen = { version = "0.69.1", default-features = false , features = ["runtime"] }
 cc = "1"
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bindings = bindgen::Builder::default()
         .header("littlefs/lfs.h")
         .clang_arg(format!("--target={}", target))
+        .clang_arg("-I/usr/arm-none-eabi/include")
         .use_core()
         .ctypes_prefix("cty")
         .generate()

--- a/build.rs
+++ b/build.rs
@@ -11,8 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .flag("-DLFS_NO_ERROR")
         .file("littlefs/lfs.c")
         .file("littlefs/lfs_util.c")
-        .file("string.c")
-    ;
+        .file("string.c");
 
     #[cfg(not(feature = "assertions"))]
     let builder = builder.flag("-DLFS_NO_ASSERT");
@@ -30,7 +29,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clang_arg(format!("--target={}", target))
         .use_core()
         .ctypes_prefix("cty")
-        .rustfmt_bindings(true)
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
> This release bumps the on-disk minor version of littlefs from lfs2.0 -> lfs2.1.
>
> This change is backwards-compatible, but after the first write with the new version, the image on disk will no longer be mountable by older versions of littlefs.

This should cause any backward compatibility issues, but we should be certain when we do this update, as rollbacks won't be possible.

For example if Nitrokey publishes a test release with this update, users would be able to roll back to a stable release without this change, which would make the filesystem unreadable.