### PR TITLE
Update bindgen for RISCV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/nickray/littlefs2-sys"
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = { version = "0.56.0", default-features = false , features = ["runtime"] }
+bindgen = { version = "0.66.1", default-features = false , features = ["runtime"] }
 cc = "1"
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = cc::Build::new();
-    let target = env::var("TARGET")?;
     let builder = builder
         .flag("-std=c11")
         .flag("-DLFS_NO_DEBUG")
@@ -11,8 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .flag("-DLFS_NO_ERROR")
         .file("littlefs/lfs.c")
         .file("littlefs/lfs_util.c")
-        .file("string.c")
-    ;
+        .file("string.c");
 
     #[cfg(not(feature = "assertions"))]
     let builder = builder.flag("-DLFS_NO_ASSERT");
@@ -27,7 +25,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bindings = bindgen::Builder::default()
         .header("littlefs/lfs.h")
-        .clang_arg(format!("--target={}", target))
         .use_core()
         .ctypes_prefix("cty")
         .rustfmt_bindings(true)


### PR DESCRIPTION
This pull request comes from some experimenting with an esp32c6, littlefs, and https://github.com/esp-rs/esp-hal.

While compiling I hit https://github.com/rust-lang/rust-bindgen/issues/2136 which appears to be fixed in updated versions of bindgen.

I also had to remove the clang_arg target from #1 for the target to get set properly. Unfortunately, I don't have access to a MacOS environment to test if this arg is still needed for MacOS.

With these changes I'm able to write and read a basic file from a micro SD card on the esp32c6.