### PR TITLE
malloc feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `malloc` feature flag. It allows `littlefs` to link to `malloc` and `free` instead of relying on the caller to allocate memory ([#9])
+
 ## [0.1.7] - 2022-01-26
 
 ### Fixed
@@ -13,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed compilation issue caused by other crates also using `bindgen` by selecting the `runtime` feature ([#5])
 
 [#5]: https://github.com/trussed-dev/littlefs2-sys/pull/5
+[#9]: https://github.com/trussed-dev/littlefs2-sys/pull/9
 
 [Unreleased]: https://github.com/trussed-dev/littlefs2-sys/compare/0.1.7...HEAD
 [0.1.7]: https://github.com/trussed-dev/littlefs2-sys/compare/0.1.6...0.1.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ cc = "1"
 [features]
 assertions = []
 trace = []
+malloc = []

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let target = env::var("TARGET")?;
     let builder = builder
         .flag("-std=c11")
-        .flag("-DLFS_NO_MALLOC")
         .flag("-DLFS_NO_DEBUG")
         .flag("-DLFS_NO_WARN")
         .flag("-DLFS_NO_ERROR")
@@ -20,6 +19,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(feature = "trace")]
     let builder = builder.flag("-DLFS_YES_TRACE");
+
+    #[cfg(not(feature = "malloc"))]
+    builder.flag("-DLFS_NO_MALLOC");
 
     builder.compile("lfs-sys");
 


### PR DESCRIPTION
Hi,

I've run into use cases where I want littlefs to link to malloc. This PR adds a feature flag, which when set, does not define "LFS_NO_MALLOC" when building littlefs.