### PR TITLE
Upgrade bindgen to 0.69.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `malloc` feature flag. It allows `littlefs` to link to `malloc` and `free` instead of relying on the caller to allocate memory ([#9])
+- upgrade `bindgen` to 0.69.4 and limit symbols to those prefixed with `lfs_` and `LFS_` ([#10])
 
 ## [0.1.7] - 2022-01-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/nickray/littlefs2-sys"
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = { version = "0.56.0", default-features = false , features = ["runtime"] }
+bindgen = { version = "0.69.4", default-features = false , features = ["runtime"] }
 cc = "1"
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clang_arg(format!("--target={}", target))
         .use_core()
         .ctypes_prefix("cty")
-        .rustfmt_bindings(true)
+        .allowlist_item("lfs_.*")
+        .allowlist_item("LFS_.*")
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
Upgrade bindgen to 0.69.4
Remove unneeded `.rustfmt_bindings(true)` as its now the default
Filter symbols to only include those prefixed with `lfs_` and `LFS_`