### PR TITLE
Use core::ffi::* instead of cty::*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Changed
 
 - upgrade `bindgen` to 0.69.4 and limit symbols to those prefixed with `lfs_` and `LFS_` ([#10])
+- Use `core::ffi::*` instead of `cty::*`
 
 [#10]: https://github.com/trussed-dev/littlefs2-sys/pull/10
 [#12]: https://github.com/trussed-dev/littlefs2-sys/pull/12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ readme = "README.md"
 categories = ["embedded", "filesystem", "no-std"]
 repository = "https://github.com/nickray/littlefs2-sys"
 
-[dependencies]
-cty = "0.2.1"
-
 [build-dependencies]
 bindgen = { version = "0.69.4", default-features = false , features = ["runtime"] }
 cc = "1"

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .header("littlefs/lfs.h")
         .clang_arg(format!("--target={}", target))
         .use_core()
-        .ctypes_prefix("cty")
         .allowlist_item("lfs_.*")
         .allowlist_item("LFS_.*")
         .generate()


### PR DESCRIPTION
Since Rust 1.64.0, the C-compatible typedefs are also available in core so we no longer need the cty dependency.