### PR TITLE
allow string.c to be disabled when it conflicts with other libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add feature to disable compiling string.c when it conflicts with other libs.
+- Add feature to disable compiling string.c when it conflicts with other libs. ([#15]())
 
 ## [0.2.0] - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add feature to disable compiling string.c when it conflicts with other libs.
+
 ## [0.2.0] - 2024-05-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 categories = ["embedded", "filesystem", "no-std"]
 repository = "https://github.com/nickray/littlefs2-sys"
 
+
 [build-dependencies]
 bindgen = { version = "0.69.4", default-features = false , features = ["runtime"] }
 cc = "1"
@@ -18,3 +19,15 @@ assertions = []
 trace = []
 malloc = []
 software-intrinsics = []
+
+# Enable this feature when you are linking with other libraries that also 
+# define these functions and you are getting multiple definition errors.
+# If you enable this then you need to insure that the following c functions
+# are available:
+# - strspn
+# - strcspn
+# - strlen
+# - strchr
+# one way is to use the `tinyrlibc` crate and enable those features that
+# are still missing.
+have-string-funcs = []

--- a/build.rs
+++ b/build.rs
@@ -10,8 +10,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .flag("-DLFS_NO_WARN")
         .flag("-DLFS_NO_ERROR")
         .file("littlefs/lfs.c")
-        .file("littlefs/lfs_util.c")
-        .file("string.c");
+        .file("littlefs/lfs_util.c");
+
+    #[cfg(not(feature = "have-string-funcs"))]
+    let builder = builder.file("string.c");
 
     #[cfg(feature = "software-intrinsics")]
     let builder = builder.flag("-DLFS_NO_INTRINSICS");


### PR DESCRIPTION
There are other crates that are based on C libs and define various functions like `strchr`.  This PR adds a feature that when enabled does not compile `string.c` and expects some external source to provide the functions within.

I ran into this issue with the current (unreleased) `esp-wifi` that when combined with littlefs2 fails to link because `strchr` is multiply defined.

When combining crates that do this one can disable `string.c` and if needed add this to fill in any functions that are still missing:
```
tinyrlibc = { version = "0.4.0", features = ["strspn", "strcspn", "strlen"] }
```
