### PR TITLE
don't set clang target as its already handled in bindgen by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build script for platforms where the Rust target is not equal to the clang target ([#16](https://github.com/trussed-dev/littlefs2-sys/pull/16))
+
 ## [0.2.0] - 2024-05-28
 
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = cc::Build::new();
-    let target = env::var("TARGET")?;
     let builder = builder
         .flag("-std=c11")
         .flag("-DLFS_NO_DEBUG")
@@ -29,7 +28,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bindings = bindgen::Builder::default()
         .header("littlefs/lfs.h")
-        .clang_arg(format!("--target={}", target))
         .use_core()
         .allowlist_item("lfs_.*")
         .allowlist_item("LFS_.*")


### PR DESCRIPTION
There is no need to set the clang_target as its [already being defaulted to TARGET](https://github.com/rust-lang/rust-bindgen/blob/f518815cc14a7f8c292964bb37179a1070d7e18a/bindgen/lib.rs#L733).  Besides passing the rust target is wrong for some targets as llvm's targets are slightly different ([see this mapping](https://github.com/rust-lang/rust-bindgen/blob/f518815cc14a7f8c292964bb37179a1070d7e18a/bindgen/lib.rs#L685)) causing it to fail on some TARGETS with:
```
  error: unknown target triple 'riscv32imac-unknown-none-elf'
  thread 'main' panicked at /Users/chris.l/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.69.4/ir/context.rs:556:15:
  libclang error; possible causes include:
  - Invalid flag syntax
  - Unrecognized flags
  - Invalid flag arguments
  - File I/O errors
  - Host vs. target architecture mismatch
  If you encounter an error missing from this list, please file an issue or a PR!
```
