### PR TITLE
Bump littlefs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update littlefs to [v2.9.3](https://github.com/littlefs-project/littlefs/releases/tag/v2.9.3)
+  - Add `multiversion` feature
+
 ### Fixed
 
 - Fix build script for platforms where the Rust target is not equal to the clang target ([#16](https://github.com/trussed-dev/littlefs2-sys/pull/16))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["embedded", "filesystem", "no-std"]
 repository = "https://github.com/nickray/littlefs2-sys"
 
 [build-dependencies]
-bindgen = { version = "0.69.4", default-features = false , features = ["runtime"] }
+bindgen = { version = "0.70.1", default-features = false , features = ["runtime"] }
 cc = "1"
 
 [features]
@@ -18,3 +18,4 @@ assertions = []
 trace = []
 malloc = []
 software-intrinsics = []
+multiversion = []

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = cc::Build::new();
     let builder = builder
-        .flag("-std=c11")
+        .flag("-std=c99")
         .flag("-DLFS_NO_DEBUG")
         .flag("-DLFS_NO_WARN")
         .flag("-DLFS_NO_ERROR")
@@ -24,17 +24,42 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(not(feature = "malloc"))]
     builder.flag("-DLFS_NO_MALLOC");
 
+    #[cfg(feature = "multiversion")]
+    let builder = builder.flag("-DLFS_MULTIVERSION");
+
     builder.compile("lfs-sys");
 
+    // Patch lfs.h to remove the lfs_util import because clang fails to locate the
+    // libraries for the custom target (especially string.h)
+    // Compilation before that succeeds because it's using gcc,
+    // which comes as a distribution with these utils.
+    // Turns out lfs_utils is not used in lfs.h, and clang properly finds stdint.h and stdbool,
+    // but not string.h
+    let lfs_h = std::fs::read_to_string("littlefs/lfs.h").expect("Reading lfs.h succeeds");
+    println!("cargo::rerun-if-changed=littlefs/lfs.h");
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_lfs_h = out_path.join("lfs.h");
+    std::fs::write(
+        &out_lfs_h,
+        lfs_h.replace(
+            r##"#include "lfs_util.h""##,
+            "#include <stdint.h>\n#include <stdbool.h>",
+        ),
+    )
+    .expect("Failed to write lfs.h");
+
     let bindings = bindgen::Builder::default()
-        .header("littlefs/lfs.h")
+        .header(out_lfs_h.into_os_string().into_string().unwrap())
+        .clang_arg("-std=c99")
+        .clang_arg("-DLFS_NO_DEBUG")
+        .clang_arg("-DLFS_NO_WARN")
+        .clang_arg("-DLFS_NO_ERROR")
         .use_core()
         .allowlist_item("lfs_.*")
         .allowlist_item("LFS_.*")
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");


### PR DESCRIPTION
This patch:

- Bumps the littlefs version to the latest released (v2.9.3)
- Adds a "multiversion" feature flag that exposes the littlefs feature of the same name
- Patch lfs.h before building to avoid errors from clang failing to find the string.h header (this step is not required for the compilation because compilation is done through gcc by default)