### PR TITLE
Fix code generation with multiversion feature and release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -
 
+## [0.3.1] - 2025-02-27
+
+### Fixed
+
+- Fix code generation with `multiversion` feature
+
 ## [0.3.0] - 2025-02-26
 
 ### Changed
@@ -45,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#5]: https://github.com/trussed-dev/littlefs2-sys/pull/5
 [#9]: https://github.com/trussed-dev/littlefs2-sys/pull/9
 
-[Unreleased]: https://github.com/trussed-dev/littlefs2-sys/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/littlefs2-sys/compare/0.3.1...HEAD
 [0.1.7]: https://github.com/trussed-dev/littlefs2-sys/compare/0.1.6...0.1.7
 [0.2.0]: https://github.com/trussed-dev/littlefs2-sys/compare/0.1.7...0.2.0
 [0.3.0]: https://github.com/trussed-dev/littlefs2-sys/compare/0.2.0...0.3.0
+[0.3.1]: https://github.com/trussed-dev/littlefs2-sys/compare/0.3.0...0.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "littlefs2-sys"
 description = "Low-level bindings to littlefs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Nicolas Stalder <n@stalder.io>", "The Trussed Developers"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/build.rs
+++ b/build.rs
@@ -48,12 +48,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .expect("Failed to write lfs.h");
 
-    let bindings = bindgen::Builder::default()
+    let bindgen = bindgen::Builder::default()
         .header(out_lfs_h.into_os_string().into_string().unwrap())
         .clang_arg("-std=c99")
         .clang_arg("-DLFS_NO_DEBUG")
         .clang_arg("-DLFS_NO_WARN")
-        .clang_arg("-DLFS_NO_ERROR")
+        .clang_arg("-DLFS_NO_ERROR");
+
+    #[cfg(feature = "multiversion")]
+    let bindgen = bindgen.clang_arg("-DLFS_MULTIVERSION");
+
+    let bindings = bindgen
         .use_core()
         .allowlist_item("lfs_.*")
         .allowlist_item("LFS_.*")


### PR DESCRIPTION
During rebasing of https://github.com/trussed-dev/littlefs2-sys/pull/19, the line that enables the LFS_MULTIVERSION feature flag not only for the compilation but also for the code generation somehow got lost.  This patch updates the build script and prepares the bugfix release v0.3.1.