### PR TITLE
Derive Default if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--
+### Added
+
+- Derive `Default` if possible
 
 ## [0.3.1] - 2025-02-27
 

--- a/build.rs
+++ b/build.rs
@@ -59,6 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bindgen = bindgen.clang_arg("-DLFS_MULTIVERSION");
 
     let bindings = bindgen
+        .derive_default(true)
         .use_core()
         .allowlist_item("lfs_.*")
         .allowlist_item("LFS_.*")


### PR DESCRIPTION
This makes it easier to initialize structs without using unsafe code.