### PR TITLE
Add a `unstable-disable-block-count-check` feature that removes the block count check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ trace = []
 malloc = []
 software-intrinsics = []
 multiversion = []
+
+unstable-disable-block-count-check = []

--- a/remove-mount-check.patch
+++ b/remove-mount-check.patch
@@ -1,0 +1,31 @@
+--- lfs.c	2025-04-14 12:03:45.959258416 +0200
++++ lfs.c.patched	2025-04-14 12:03:23.044370382 +0200
+@@ -4521,15 +4521,20 @@
+             }
+ 
+             // this is where we get the block_count from disk if block_count=0
+-            if (lfs->cfg->block_count
+-                    && superblock.block_count != lfs->cfg->block_count) {
+-                LFS_ERROR("Invalid block count (%"PRIu32" != %"PRIu32")",
+-                        superblock.block_count, lfs->cfg->block_count);
+-                err = LFS_ERR_INVAL;
+-                goto cleanup;
+-            }
++            // 
++            // if (lfs->cfg->block_count
++            //         && superblock.block_count != lfs->cfg->block_count) {
++            //     LFS_ERROR("Invalid block count (%"PRIu32" != %"PRIu32")",
++            //             superblock.block_count, lfs->cfg->block_count);
++            //     err = LFS_ERR_INVAL;
++            //     goto cleanup;
++            // }
+ 
+-            lfs->block_count = superblock.block_count;
++            if (lfs->cfg->block_count) {
++                lfs->block_count = lfs->cfg->block_count;
++            } else {
++                lfs->block_count = superblock.block_count;
++            }
+ 
+             if (superblock.block_size != lfs->cfg->block_size) {
+                 LFS_ERROR("Invalid block size (%"PRIu32" != %"PRIu32")",


### PR DESCRIPTION
Upstream PR: https://github.com/littlefs-project/littlefs/pull/584 introduced a check that the block count matches the superblock.

However that can cause some issues for filesystem that were formatted with a wrong block count and later corrected.