### PR TITLE
Update littlefs including shrinking and block count check flag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "littlefs"]
 	path = littlefs
-	url = https://github.com/ARMmbed/littlefs
+	url = https://github.com/trussed-dev/littlefs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,3 @@ trace = []
 malloc = []
 software-intrinsics = []
 multiversion = []
-
-unstable-disable-block-count-check = []


### PR DESCRIPTION
This does not update to 2.10 because the path handling changes do break a lot of code. So right now this uses a fork with the following two patches backported:

- https://github.com/littlefs-project/littlefs/pull/1096
- https://github.com/littlefs-project/littlefs/pull/1094