### PR TITLE
Add LITTLEFS_CONFIG support and adjust bindings for wasm32 target

### DIFF
--- a/string.c
+++ b/string.c
@@ -5,7 +5,7 @@
  *  Copyright (C) 1991, 1992  Linus Torvalds
  */
 
-#include <string.h>
+#include <stddef.h>
 
 size_t strspn(const char *s, const char *accept)
 {


### PR DESCRIPTION
Hi,
Thanks for this very useful repository.
This pull request introduces enhancements to the build configuration in `build.rs` and a minor header file adjustment in `string.c`. The key changes include adding support for environment-based configuration and [`fvisibility` fix for wasm32 for bindgen](https://github.com/rust-lang/rust-bindgen/issues/2989#issuecomment-2526268308) in the build script and replacing a header file in `string.c`, improving portability for bare metal environment (for example `wasm32_unknown_unknown` target).